### PR TITLE
Allow react@17 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/theKashey/react-focus-lock/issues"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
Tested. It works! This will prevent npm warning.